### PR TITLE
Añadir espacios para anuncios de Google AdSense

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,6 @@
 #root {
-  max-width: 1280px;
+  max-width: 100%;
   margin: 0 auto;
-  padding: 2rem;
   text-align: center;
 }
 

--- a/src/components/AdPlaceholder.tsx
+++ b/src/components/AdPlaceholder.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
+
+interface AdPlaceholderProps {
+  type: 'vertical' | 'horizontal';
+  label: string;
+}
+
+const AdPlaceholder: React.FC<AdPlaceholderProps> = ({ type, label }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const styles = {
+    vertical: {
+      width: '160px',
+      height: '600px',
+      display: isMobile ? 'none' : 'flex',
+    },
+    horizontal: {
+      width: '100%',
+      maxWidth: '728px',
+      height: '90px',
+      display: 'flex',
+      margin: '20px auto',
+    },
+  };
+
+  return (
+    <Box
+      sx={{
+        ...styles[type],
+        backgroundColor: 'rgba(0, 0, 0, 0.05)',
+        border: '1px dashed #ccc',
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+        position: 'relative',
+        '&::before': {
+          content: '"ANUNCIO"',
+          position: 'absolute',
+          bottom: '5px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          fontSize: '10px',
+          color: 'text.secondary',
+          opacity: 0.5,
+        }
+      }}
+    >
+      {/*
+          ZONA PARA CÓDIGO DE ADSENSE - {label}
+          Pega aquí el código <ins> de tu anuncio de Google AdSense.
+          Recuerda también incluir el script de AdSense en index.html si no lo has hecho.
+      */}
+      <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center', p: 1 }}>
+        Espacio para anuncio {type === 'vertical' ? '160x600' : 'Horizontal'}
+        <br />
+        ({label})
+      </Typography>
+
+      {/*
+          Ejemplo de integración (Descomenta y adapta cuando tengas tu código):
+
+          <ins className="adsbygoogle"
+               style={{ display: 'block' }}
+               data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
+               data-ad-slot="XXXXXXXXXX"
+               data-ad-format={type === 'vertical' ? 'vertical' : 'horizontal'}
+               data-full-width-responsive="true"></ins>
+          <script>
+               (adsbygoogle = window.adsbygoogle || []).push({});
+          </script>
+      */}
+    </Box>
+  );
+};
+
+export default AdPlaceholder;

--- a/src/components/BannerOptimizer.tsx
+++ b/src/components/BannerOptimizer.tsx
@@ -13,6 +13,7 @@ import {
   Archive as ArchiveIcon,
 } from '@mui/icons-material';
 import JSZip from 'jszip';
+import AdPlaceholder from './AdPlaceholder';
 
 const getFileExtension = (mimeType: string) => {
   switch (mimeType) {
@@ -426,7 +427,30 @@ const BannerOptimizer: React.FC = () => {
   }, [files, showToast]);
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 4, position: 'relative' }}>
+      {/* Anuncios Laterales (Escritorio) */}
+      <Box sx={{
+        display: { xs: 'none', xl: 'block' },
+        position: 'fixed',
+        left: '20px',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        zIndex: 10
+      }}>
+        <AdPlaceholder type="vertical" label="Lateral Izquierdo" />
+      </Box>
+
+      <Box sx={{
+        display: { xs: 'none', xl: 'block' },
+        position: 'fixed',
+        right: '20px',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        zIndex: 10
+      }}>
+        <AdPlaceholder type="vertical" label="Lateral Derecho" />
+      </Box>
+
       <Box sx={{ textAlign: 'center', mb: 8 }}>
         <Chip icon={<ZapIcon />} label="Banner Optimizer" color="primary" sx={{ mb: 2 }} />
         <Typography variant="h3" component="h1" gutterBottom>
@@ -436,6 +460,9 @@ const BannerOptimizer: React.FC = () => {
           Upload your images and we'll automatically convert them to standard banner formats
           with optimized file sizes for web use.
         </Typography>
+
+        {/* Anuncio Horizontal Superior (Móvil y Escritorio) */}
+        <AdPlaceholder type="horizontal" label="Superior" />
       </Box>
 
       <Grid container spacing={2} sx={{ mb: 4 }}>
@@ -499,6 +526,11 @@ const BannerOptimizer: React.FC = () => {
           </Grid>
         </Box>
       )}
+
+      {/* Anuncio Horizontal Inferior (Móvil y Escritorio) */}
+      <Box sx={{ mt: 8 }}>
+        <AdPlaceholder type="horizontal" label="Inferior" />
+      </Box>
 
       <Snackbar
         open={snackbar.open}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,15 @@ const theme = createTheme({
       paper: '#1e1e1e',
     },
   },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 600,
+      md: 900,
+      lg: 1200,
+      xl: 1600, // Definimos XL para pantallas muy anchas donde caben anuncios laterales
+    },
+  },
 });
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
He completado la integración de los espacios para anuncios de Google AdSense tal como lo solicitaste:

1. **Anuncios Verticales (160x600):** He añadido dos espacios a los lados que se quedan fijos (sticky) mientras haces scroll. Estos solo aparecen en pantallas anchas (más de 1600px) para no tapar el contenido de la herramienta.
2. **Anuncios Horizontales:** He añadido un espacio después del título/subtítulo y otro al final de la página. Estos se adaptan tanto a móviles como a escritorio.
3. **Fácil de usar:** He creado un archivo `src/components/AdPlaceholder.tsx` donde encontrarás comentarios claros que dicen "ZONA PARA CÓDIGO DE ADSENSE". Solo tienes que pegar tu código ahí.
4. **Instrucciones adicionales:** Recuerda que para que AdSense funcione, debes incluir el script principal de AdSense en tu archivo `index.html`.

Los cambios han sido verificados visualmente en diferentes tamaños de pantalla (móvil, escritorio estándar y escritorio panorámico).

---
*PR created automatically by Jules for task [11566034439832911089](https://jules.google.com/task/11566034439832911089) started by @Atremenyu*